### PR TITLE
move sbt/ivy artifact stores to allow caching

### DIFF
--- a/bin/cache-init.sh
+++ b/bin/cache-init.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+# setting $HOME to "/drone" allows all .sbt and .ivy2 dependencies to be cached
+# paulp sbt wrapper *always* downloads the sbt launcher to ~/.sbt/...
+# otherwise we could do nicer overrides of just the ivy and sbt dirs.
+REAL_HOME="${HOME}"
+HOME="${DRONE_DIR}"
+
+CACHE_DIRS=".ivy2 .sbt"
+
+for dir in ${CACHE_DIRS} ; do
+    # create cache dirs
+    mkdir -p ${HOME}/${dir}
+    # setup symlinks from /drone/ to real home dir for paulp wrapper
+    ln -sf ${HOME}/${dir} ${REAL_HOME}/${dir}
+done

--- a/bin/credential-init.sh
+++ b/bin/credential-init.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env sh
 
-CREDENTIAL_FILE=${HOME}/.ivy2/.credentials
+# many internal projects use ~/.ivy/.credentials to store artifact repo creds
+# this hackery pulls the credentials from the CI environement but ensures they
+# aren't cached along with the ivy cache
+
+SBT_CREDENTIAL_FILE=${HOME}/.ivy2/.credentials
+REAL_CREDENTIAL_FILE=${REAL_HOME}/.credentials/sbt-credentials
 
 if [ -n "${ARTIFACTORY_USER}" -a -n "${ARTIFACTORY_PASSWORD}" -a -n "${ARTIFACTORY_HOST}" ] ; then
     echo -n "Creating Artifactory credentials... "
-    mkdir -p ${HOME}/.ivy2
-    cat > $CREDENTIAL_FILE << EOFEOFEOF
+    mkdir -p ${HOME}/.ivy2 $(dirname ${REAL_CREDENTIAL_FILE})
+
+    ln -sf "${REAL_CREDENTIAL_FILE}" "${SBT_CREDENTIAL_FILE}"
+
+    cat > ${REAL_CREDENTIAL_FILE} << EOFEOFEOF
 realm=Artifactory Realm
 host=${ARTIFACTORY_HOST}
 user=${ARTIFACTORY_USER}

--- a/bin/sbt
+++ b/bin/sbt
@@ -8,10 +8,11 @@ if [ "${CI}" == "drone" ] ; then
     echo "Drone CI detected."
     export DRONE_DIR="/drone"
     CI_SETUP_SENTINEL="${DRONE_DIR}/.ci-stamp"
-    SCRIPTS_DIR="/usr/local/bin"
+
+    . ${SCRIPTS_DIR}/cache-init.sh
 
     if [ ! -f ${CI_SETUP_SENTINEL} ] ; then
-	touch ${CI_SETUP_SENTINEL}
+        touch ${CI_SETUP_SENTINEL}
         . ${SCRIPTS_DIR}/credential-init.sh
     fi
 else


### PR DESCRIPTION
drone cache plugins can only cache files located in /drone/. both the
sbt and ivy caches are now moved within this dir, while also keeping the
credentials file outside /drone/ so they can't be persisted
accidentally.

to simplify the process, I'm setting $HOME to /drone/ to allow sbt and
ivy to automatically put files in the right locations. symlinks are also
created in the real home directory that point to this new location

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aboyett/sbt-docker-builder/1)
<!-- Reviewable:end -->
