### PR TITLE
refactor to ease maintainability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,3 @@ RUN apk add --no-cache bash ca-certificates git wget
 RUN wget https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt -O /usr/local/bin/sbt-paulp && chmod +x /usr/local/bin/sbt-paulp
 
 COPY bin/ /usr/local/bin/
-
-ENTRYPOINT ["bash"]

--- a/bin/cache-init.sh
+++ b/bin/cache-init.sh
@@ -1,16 +1,10 @@
 #!/usr/bin/env sh
 
-# setting $HOME to "/drone" allows all .sbt and .ivy2 dependencies to be cached
-# paulp sbt wrapper *always* downloads the sbt launcher to ~/.sbt/...
-# otherwise we could do nicer overrides of just the ivy and sbt dirs.
-REAL_HOME="${HOME}"
-HOME="${DRONE_DIR}"
+PKG_CACHE_DIRS=".ivy2 .sbt"
 
-CACHE_DIRS=".ivy2 .sbt"
-
-for dir in ${CACHE_DIRS} ; do
+for dir in ${PKG_CACHE_DIRS} ; do
     # create cache dirs
-    mkdir -p ${HOME}/${dir}
-    # setup symlinks from /drone/ to real home dir for paulp wrapper
-    ln -sf ${HOME}/${dir} ${REAL_HOME}/${dir}
+    mkdir -p ${CACHE_DIR}/${dir}
+    # setup symlinks from /drone/ to home dir for paulp wrapper
+    ln -sf ${CACHE_DIR}/${dir} ${HOME}/${dir}
 done

--- a/bin/credential-init.sh
+++ b/bin/credential-init.sh
@@ -1,25 +1,30 @@
 #!/usr/bin/env sh
 
-# many internal projects use ~/.ivy/.credentials to store artifact repo creds
-# this hackery pulls the credentials from the CI environement but ensures they
-# aren't cached along with the ivy cache
+CI_CREDENTIAL_SENTINEL="${HOME}/.ci-creds-stamp"
+SBT_CREDENTIAL_FILE=${HOME}/.credentials/sbt-credentials
 
-SBT_CREDENTIAL_FILE=${HOME}/.ivy2/.credentials
-REAL_CREDENTIAL_FILE=${REAL_HOME}/.credentials/sbt-credentials
+# setup credentials and touch sentinel file
+if [ ! -f "${CI_SETUP_SENTINEL}" ] ; then
+    if [ -n "${ARTIFACTORY_USER}" -a -n "${ARTIFACTORY_PASSWORD}" -a -n "${ARTIFACTORY_HOST}" ] ; then
+        echo -n "Creating Artifactory credentials... "
+        mkdir -p $(dirname ${SBT_CREDENTIAL_FILE})
 
-if [ -n "${ARTIFACTORY_USER}" -a -n "${ARTIFACTORY_PASSWORD}" -a -n "${ARTIFACTORY_HOST}" ] ; then
-    echo -n "Creating Artifactory credentials... "
-    mkdir -p ${HOME}/.ivy2 $(dirname ${REAL_CREDENTIAL_FILE})
-
-    ln -sf "${REAL_CREDENTIAL_FILE}" "${SBT_CREDENTIAL_FILE}"
-
-    cat > ${REAL_CREDENTIAL_FILE} << EOFEOFEOF
+        cat > ${SBT_CREDENTIAL_FILE} << EOFEOFEOF
 realm=Artifactory Realm
 host=${ARTIFACTORY_HOST}
 user=${ARTIFACTORY_USER}
 password=${ARTIFACTORY_PASSWORD}
 EOFEOFEOF
-    echo "Done!"
-else
-    echo "Skipping Artifactory credential creation. \$ARTIFACTORY_USER and \$ARTIFACTORY_PASSWORD are not set."
+        echo "Done!"
+    else
+        echo "Skipping Artifactory credential creation. \$ARTIFACTORY_USER and \$ARTIFACTORY_PASSWORD are not set."
+    fi
+
+    touch ${CI_CREDENTIAL_SENTINEL}
+fi
+
+# sbt will read credentials from a file if the path is set in SBT_CREDENTIALS
+# https://github.com/sbt/sbt/commit/96e5a7957c830430f85b6b89d7bbe07824ebfc4b
+if [ -f "${SBT_CREDENTIAL_FILE}" ] ; then
+    export SBT_CREDENTIALS=${SBT_CREDENTIAL_FILE}
 fi

--- a/bin/sbt
+++ b/bin/sbt
@@ -6,7 +6,7 @@ SCRIPTS_DIR="/usr/local/bin"
 
 if [ "${CI}" == "drone" ] ; then
     echo "Drone CI detected."
-    export DRONE_DIR="/drone"
+    export CACHE_DIR="/drone"
 
     . ${SCRIPTS_DIR}/cache-init.sh
     . ${SCRIPTS_DIR}/credential-init.sh

--- a/bin/sbt
+++ b/bin/sbt
@@ -7,14 +7,9 @@ SCRIPTS_DIR="/usr/local/bin"
 if [ "${CI}" == "drone" ] ; then
     echo "Drone CI detected."
     export DRONE_DIR="/drone"
-    CI_SETUP_SENTINEL="${DRONE_DIR}/.ci-stamp"
 
     . ${SCRIPTS_DIR}/cache-init.sh
-
-    if [ ! -f ${CI_SETUP_SENTINEL} ] ; then
-        touch ${CI_SETUP_SENTINEL}
-        . ${SCRIPTS_DIR}/credential-init.sh
-    fi
+    . ${SCRIPTS_DIR}/credential-init.sh
 else
     echo "CI environment not detected. Running sbt without special preparation."
 fi


### PR DESCRIPTION
This PR attempts to make this project more maintainable by simplifying
codepaths and generalizing the code-base rather than depending on
drone-specific assumptions.

Changes of note:
- eliminated the defined container entrypoint. Drone never used it so we didn't
  notice it was broken.
- generalized SBT crendential passing behavior. SBT can be passed a credential
  file to use via the `SBT_CREDENTIALS` environment variable
- moved stateful credential logic to within `bin/credentials-init.sh` to
  simplify the sbt wrapper itself
- removed the rewriting of the `HOME` environment variable in favor of using
  only symlinks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aboyett/sbt-docker-builder/2)
<!-- Reviewable:end -->
